### PR TITLE
Create personal website homepage with project links

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Danny | Personal Website</title>
+  <meta name="description" content="Personal website for Danny featuring projects, skills, and contact links." />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="hero">
+    <nav class="nav">
+      <a class="logo" href="#">Danny</a>
+      <ul>
+        <li><a href="#about">About</a></li>
+        <li><a href="#projects">Projects</a></li>
+        <li><a href="#contact">Contact</a></li>
+      </ul>
+    </nav>
+
+    <div class="hero-content">
+      <p class="eyebrow">Hello, I'm</p>
+      <h1>Danny G.</h1>
+      <p class="tagline">I build playful web experiences and useful tools.</p>
+      <a class="button" href="#projects">See My Work</a>
+    </div>
+  </header>
+
+  <main>
+    <section id="about" class="card">
+      <h2>About Me</h2>
+      <p>
+        I'm a developer who enjoys creating interactive websites and browser-based games.
+        I care about clean UI, solid performance, and shipping projects that people enjoy using.
+      </p>
+      <ul class="skills">
+        <li>JavaScript</li>
+        <li>HTML/CSS</li>
+        <li>Front-end Architecture</li>
+        <li>Game Prototyping</li>
+      </ul>
+    </section>
+
+    <section id="projects" class="card">
+      <h2>Featured Projects</h2>
+      <div class="project-grid">
+        <a class="project" href="dashboard/index.html">
+          <h3>Dashboard</h3>
+          <p>Data-focused interface with modular components.</p>
+        </a>
+        <a class="project" href="platformer/index.html">
+          <h3>Platformer</h3>
+          <p>Browser platform game with responsive controls.</p>
+        </a>
+        <a class="project" href="hvac-website/index.html">
+          <h3>HVAC Website</h3>
+          <p>Service business site with clear calls to action.</p>
+        </a>
+        <a class="project" href="dodge/index.html">
+          <h3>Dodge Game</h3>
+          <p>Fast-paced survival mini-game built for fun.</p>
+        </a>
+      </div>
+    </section>
+
+    <section id="contact" class="card">
+      <h2>Contact</h2>
+      <p>Want to collaborate or hire me for a project? Let's connect.</p>
+      <div class="contact-links">
+        <a href="mailto:danny@example.com">Email</a>
+        <a href="https://github.com" target="_blank" rel="noreferrer">GitHub</a>
+        <a href="https://www.linkedin.com" target="_blank" rel="noreferrer">LinkedIn</a>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <p>© <span id="year"></span> Danny G. All rights reserved.</p>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,1 @@
+document.getElementById('year').textContent = new Date().getFullYear();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,172 @@
+:root {
+  --bg: #0f172a;
+  --surface: #111827;
+  --surface-2: #1f2937;
+  --text: #e5e7eb;
+  --muted: #9ca3af;
+  --accent: #22d3ee;
+  --accent-2: #38bdf8;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+  background: radial-gradient(circle at top, #1e293b, var(--bg));
+  color: var(--text);
+  line-height: 1.6;
+}
+
+.hero {
+  min-height: 60vh;
+  padding: 1.5rem 1.25rem 3rem;
+}
+
+.nav {
+  max-width: 960px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.logo {
+  color: var(--text);
+  text-decoration: none;
+  font-weight: 700;
+  font-size: 1.2rem;
+}
+
+.nav ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 1rem;
+}
+
+.nav a {
+  color: var(--muted);
+  text-decoration: none;
+}
+
+.nav a:hover {
+  color: var(--text);
+}
+
+.hero-content {
+  max-width: 960px;
+  margin: 4rem auto 0;
+}
+
+.eyebrow {
+  color: var(--accent);
+  margin-bottom: 0.2rem;
+}
+
+h1 {
+  font-size: clamp(2rem, 6vw, 3.5rem);
+  margin: 0;
+}
+
+.tagline {
+  color: var(--muted);
+  max-width: 560px;
+}
+
+.button {
+  display: inline-block;
+  margin-top: 0.75rem;
+  background: linear-gradient(90deg, var(--accent), var(--accent-2));
+  color: #0b1120;
+  text-decoration: none;
+  font-weight: 600;
+  padding: 0.65rem 1rem;
+  border-radius: 999px;
+}
+
+main {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 1.25rem 3rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.card {
+  background: rgba(17, 24, 39, 0.86);
+  border: 1px solid #374151;
+  border-radius: 16px;
+  padding: 1.25rem;
+}
+
+h2 {
+  margin-top: 0;
+}
+
+.skills {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.skills li {
+  background: var(--surface-2);
+  border: 1px solid #374151;
+  border-radius: 999px;
+  padding: 0.3rem 0.7rem;
+  font-size: 0.9rem;
+}
+
+.project-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.project {
+  background: var(--surface-2);
+  border: 1px solid #334155;
+  border-radius: 12px;
+  padding: 0.85rem;
+  color: var(--text);
+  text-decoration: none;
+  transition: transform 0.15s ease, border-color 0.15s ease;
+}
+
+.project:hover {
+  transform: translateY(-2px);
+  border-color: var(--accent);
+}
+
+.project h3 {
+  margin: 0 0 0.25rem;
+}
+
+.project p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.contact-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.contact-links a {
+  color: var(--accent);
+}
+
+footer {
+  text-align: center;
+  padding: 0 1rem 2rem;
+  color: var(--muted);
+}


### PR DESCRIPTION
### Motivation
- Add a simple, focused personal homepage that aggregates projects, skills, and contact links so the repository has a clear landing page. 
- Provide a lightweight, dark-themed layout to showcase existing project pages (`dashboard`, `platformer`, `hvac-website`, and `dodge`).

### Description
- Add `index.html` containing a hero, About, Featured Projects (linked to existing pages), and Contact sections. 
- Add `styles.css` implementing a responsive dark theme, card layout, project tiles, and navigation styling. 
- Add `script.js` which dynamically inserts the current year into the footer. 

### Testing
- Ran `node --check script.js` which completed successfully. 
- Started a local static server with `python3 -m http.server 4173 --bind 0.0.0.0` and served `index.html` for manual inspection. 
- Attempted an automated screenshot with Playwright, but Chromium crashed in this environment (SIGSEGV) so the screenshot step failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0f7ca2c188333abd8004eb9014409)